### PR TITLE
fix: 비로그인 사용자 행동 로그 수집 오류 수정

### DIFF
--- a/src/features/behavior-log/model/behaviorLogStore.ts
+++ b/src/features/behavior-log/model/behaviorLogStore.ts
@@ -1,4 +1,5 @@
 import postBehaviorLog from "../api/postBehaviorLog";
+import { authStore, useAuthStore } from "@/shared/store/authStore";
 import type {
   BehaviorLogCounter,
   BehaviorLogCounterMap,
@@ -13,6 +14,7 @@ const PENDING_QUEUE_KEY = "behaviorLog:pendingQueue";
 let countersCache: BehaviorLogCounterMap | null = null;
 let queueCache: BehaviorLogRequest[] | null = null;
 let flushPromise: Promise<void> | null = null;
+let disabledAccessToken: string | null = null;
 
 function isBrowser() {
   return typeof window !== "undefined";
@@ -37,6 +39,42 @@ function storageSet<T>(key: string, value: T) {
 function storageRemove(key: string) {
   if (!isBrowser()) return;
   localStorage.removeItem(key);
+}
+
+function clearCounters() {
+  countersCache = {};
+  storageRemove(COUNTERS_KEY);
+}
+
+function clearQueue() {
+  queueCache = [];
+  storageRemove(PENDING_QUEUE_KEY);
+}
+
+function clearStoredBehaviorLogs() {
+  clearCounters();
+  clearQueue();
+}
+
+function isAuthInitialized() {
+  return useAuthStore.getState().initialized;
+}
+
+function canHandleBehaviorLogs() {
+  if (!isAuthInitialized()) return false;
+
+  const accessToken = authStore.getAccessToken();
+  if (!accessToken) return false;
+
+  return disabledAccessToken !== accessToken;
+}
+
+function disableBehaviorLogsForCurrentToken() {
+  const accessToken = authStore.getAccessToken();
+  if (accessToken) {
+    disabledAccessToken = accessToken;
+  }
+  clearStoredBehaviorLogs();
 }
 
 function createSessionId() {
@@ -163,7 +201,7 @@ function updateCounter(
   meetingId: number,
   updater: (previous: BehaviorLogCounter) => BehaviorLogCounter,
 ) {
-  if (!isBrowser()) return;
+  if (!isBrowser() || !canHandleBehaviorLogs()) return;
 
   const normalizedMeetingId = normalizeMeetingId(meetingId);
   if (!normalizedMeetingId) return;
@@ -247,7 +285,11 @@ async function flushPendingQueue({ keepalive = false }: { keepalive?: boolean } 
       queue.shift();
       sentCount += 1;
       if (keepalive) break;
-    } catch {
+    } catch (error) {
+      const apiError = error as { code?: string; status?: number };
+      if (apiError.status === 401) {
+        disableBehaviorLogsForCurrentToken();
+      }
       break;
     }
   }
@@ -263,6 +305,11 @@ type FlushBehaviorLogsOptions = {
 
 export async function flushBehaviorLogs(options: FlushBehaviorLogsOptions = {}) {
   if (!isBrowser()) return;
+  if (!isAuthInitialized()) return;
+  if (!canHandleBehaviorLogs()) {
+    clearStoredBehaviorLogs();
+    return;
+  }
   if (flushPromise) return flushPromise;
 
   flushPromise = (async () => {

--- a/src/lib/api/apiFetch.ts
+++ b/src/lib/api/apiFetch.ts
@@ -4,6 +4,15 @@ import { ApiErrorResponse, ApiFetchOptions, ApiResponse } from "./types";
 import { refreshAccessToken } from "../auth/refreshAccessToken";
 import { authStore } from "@/shared/store/authStore";
 
+function createApiError(message: string, status: number, code?: string) {
+  const error = new Error(message) as Error & { code?: string; status?: number };
+  error.status = status;
+  if (code) {
+    error.code = code;
+  }
+  return error;
+}
+
 export async function apiFetch<T>(path: string, init: ApiFetchOptions) {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL;
   if (!base) {
@@ -60,17 +69,17 @@ export async function apiFetch<T>(path: string, init: ApiFetchOptions) {
         }
 
         authStore.clear();
-        throw new Error("세션이 만료되었습니다. 다시 로그인해주세요");
+        throw createApiError("세션이 만료되었습니다. 다시 로그인해주세요", 401, error.code);
       }
 
       if (error?.code === "TOKEN_INVALID") {
         authStore.clear();
-        throw new Error("유효하지 않은 토큰입니다. 다시 로그인해주세요");
+        throw createApiError("유효하지 않은 토큰입니다. 다시 로그인해주세요", 401, error.code);
       }
 
       if (error?.code === "AUTH_UNAUTHORIZED") {
         authStore.clear();
-        throw new Error("인증이 필요합니다.");
+        throw createApiError("인증이 필요합니다.", 401, error.code);
       }
     }
 
@@ -82,12 +91,11 @@ export async function apiFetch<T>(path: string, init: ApiFetchOptions) {
           parsedError = null;
         }
       }
-      const customError = new Error(parsedError?.message ?? `API 요청 실패: ${response.status}`);
-      if (parsedError?.code) {
-        (customError as { code?: string }).code = parsedError.code;
-      }
-      (customError as { status?: number }).status = response.status;
-      throw customError;
+      throw createApiError(
+        parsedError?.message ?? `API 요청 실패: ${response.status}`,
+        response.status,
+        parsedError?.code,
+      );
     }
 
     if (response.status === 204) {


### PR DESCRIPTION
## 🦫 무엇을 위한 PR인가요?

- [ ] 신규 기능 추가
- [x] 버그 수정 
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 기타

로그인을 하지 않은 사용자는 사용자 행동기반 로그를 수집하지 않고, API 전송 요청을 보내지 않도록 수정했습니다.

<br />

## ☕️ 변경사항 및 이유

로그인을 하지 않은 사용자의 경우 사용자 행동 로그를 수집할 필요가 없는데도 불구하고 로그를 수집하고 있었으며, /behavior-logs 엔드포인트로 전송 요청을 계속 보내고 있었습니다. 따라서 authStore를 통해 토큰 발급 여부를 확인하고 인증이 된 사용자 (=로그인 된 사용자)만 행동 로그를 수집할 수 있도록 수정이 필요했습니다.


<br />

## 📚 작업 내역

**🔻 수정 전 API 호출 로그**

<img width="1119" height="117" alt="image" src="https://github.com/user-attachments/assets/fd27fc90-bb5d-4971-8491-381c4d59447f" />

<br />
<br />


## 🔗 PR 특이 사항 및  Issue Number 

없습니다.


<br />

## 🙌 어떤 부분에 리뷰어가 집중하면 좋을까요?

비로그인 사용자 탐지를 위해 기존 사용하던 공통 API 호출 유틸 함수인 `src/lib/apiFetch.ts` 를 일부 수정하였습니다. 
